### PR TITLE
fix "true" in meal participant calculation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emeal/menuplanung",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "license": "MIT",
   "copyrights": "© 2019 - 2024 Cevi Züri 11 - eMeal Menüplanung",
   "scripts": {

--- a/frontend/src/app/modules/application-module/dialoges/change-log/change-log.component.html
+++ b/frontend/src/app/modules/application-module/dialoges/change-log/change-log.component.html
@@ -1,4 +1,4 @@
-<h2>Neue Versionen - v1.15.2</h2>
+<h2>Neue Versionen - v1.15.3</h2>
 
 <div mat-dialog-content>
 
@@ -7,7 +7,7 @@
   <p>Dieses Update behebt einen Fehler:</p>
 
   <p class="news-element news-fixed">
-    Bisher hat das Berechnen einer Mahlzeit nur für Leiter*innen nicht funktioniert. Dieser Fehler wurde behoben.
+    Behebt einen Dahrstellungsfehler bei der Personenberechnung in der Rezeptansicht.
   </p>
 
 </div>

--- a/frontend/src/app/modules/application-module/dialoges/recipe-info/recipe-info.component.html
+++ b/frontend/src/app/modules/application-module/dialoges/recipe-info/recipe-info.component.html
@@ -28,7 +28,7 @@
       camp.vegetarians,
       camp.leaders,
       specificMeal.participants,
-      this.recipeForm.get('overrideParticipants').value,
+      this.recipeForm.get('overrideParticipants').value ? this.recipeForm.get('participants') : 0,
       specificMeal.overrideParticipants,
       this.recipeForm.get('overrideParticipants').value,
       this.recipeForm.get('vegi').value)

--- a/frontend/src/app/modules/application-module/dialoges/recipe-info/recipe-info.component.html
+++ b/frontend/src/app/modules/application-module/dialoges/recipe-info/recipe-info.component.html
@@ -28,7 +28,7 @@
       camp.vegetarians,
       camp.leaders,
       specificMeal.participants,
-      this.recipeForm.get('overrideParticipants').value ? this.recipeForm.get('participants') : 0,
+      this.recipeForm.get('overrideParticipants').value ? this.recipeForm.get('participants').value : 0,
       specificMeal.overrideParticipants,
       this.recipeForm.get('overrideParticipants').value,
       this.recipeForm.get('vegi').value)

--- a/frontend/src/app/modules/change-log-module/components/version-history/version-history.component.html
+++ b/frontend/src/app/modules/change-log-module/components/version-history/version-history.component.html
@@ -6,6 +6,13 @@
     Fehlerbehebungen.
   </p>
 
+
+  <h3>Neues in der Version 1.15.3 (2. Mai 2024)</h3>
+
+  <p class="news-element news-fixed">
+    Behebt einen Dahrstellungsfehler bei der Personenberechnung in der Rezeptansicht.
+  </p>
+
   <h3>Neues in der Version 1.15.2 (1. Mai 2024)</h3>
 
   <p class="news-element news-fixed">


### PR DESCRIPTION
> The funciton calcRecipeParticipants expects a number as the 5th argument, however a bool was given back from the frontend (the override checkbox value, instead of the actual value inside the override participants field)

Thanks @maede97, https://github.com/wp99cp/eMeal_menuplanung/pull/228#issue-2274971968